### PR TITLE
Context following

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -63,6 +63,7 @@ export interface SpacesSettings {
     customColors: Record<string, string>;
     tagColors: Record<string, string>;
     contextNoteIconClick: boolean;
+    contextNoteFollowActive: boolean;
     hiddenItems: Record<string, boolean>;
     portalStacks: PortalStack[];
     tabBarOrder: string[];
@@ -118,6 +119,7 @@ export const DEFAULT_SETTINGS: SpacesSettings = {
     customColors: {},
     tagColors: {},
     contextNoteIconClick: false,
+    contextNoteFollowActive: false,
     hiddenItems: {},
     portalStacks: [],
     tabBarOrder: [],
@@ -412,6 +414,18 @@ export class SpacesSettingTab extends PluginSettingTab {
                 this.plugin.settings.contextNoteIconClick = value;
                 await this.plugin.saveSettings();
                 // Refresh the view to apply cursor style
+                this.plugin.refreshAllViews();
+            }));
+
+        new Setting(containerEl)
+        .setName('Show closest context note')
+        .setDesc('When enabled, the side portal context note tab shows the context note for the active file\'s parent folder instead of the selected space.')
+        .addToggle(toggle => toggle
+            .setValue(this.plugin.settings.contextNoteFollowActive)
+            .setDisabled(!this.plugin.settings.enableContextNotes)
+            .onChange(async (value) => {
+                this.plugin.settings.contextNoteFollowActive = value;
+                await this.plugin.saveSettings();
                 this.plugin.refreshAllViews();
             }));
 

--- a/src/view.ts
+++ b/src/view.ts
@@ -919,11 +919,21 @@ export class PortalsView extends ItemView {
     }
 
     private getCurrentContextNote(): TFile | null {
+        // Resolve context note from the active file's parent folder
+        const activeFile = this.app.workspace.getActiveFile();
+        if (activeFile && activeFile.parent) {
+            const note = this.getContextNote(activeFile.parent);
+            if (note) return note;
+        }
+        // Fall back to selectedSpace when there is no active file
         const selectedSpace = this.plugin.settings.selectedSpace;
         if (!selectedSpace) return null;
         if (selectedSpace.type === 'folder') {
-            const folder = this.app.vault.getAbstractFileByPath(selectedSpace.path);
-            return folder instanceof TFolder ? this.getContextNote(folder) ?? null : null;
+            const folder =
+                this.app.vault.getAbstractFileByPath(selectedSpace.path);
+            return folder instanceof TFolder
+                ? this.getContextNote(folder) ?? null
+                : null;
         } else {
             return this.getContextNote(selectedSpace.path) ?? null;
         }
@@ -1291,6 +1301,22 @@ export class PortalsView extends ItemView {
                 const tree = this.containerEl.querySelector('.portals-tree-container') as HTMLElement | null;
                 if (tree) this.scrollToRestore = tree.scrollTop;
                 this.renderContent();
+            }
+            // Refresh context notes tab so it follows the
+            // active file's parent folder
+            if (this.plugin.settings.enableContextNotes &&
+                this.plugin.settings.activeSplitTab === 'context-notes') {
+                const sp = this.containerEl.querySelector(
+                    '.portals-secondary-panel');
+                if (sp) {
+                    const ce = sp.querySelector(
+                        '.portals-split-content');
+                    if (ce) {
+                        (ce as HTMLElement).empty();
+                        this.renderContextNotesTab(
+                            ce as HTMLElement);
+                    }
+                }
             }
         }));
         this.registerEvent(this.app.workspace.on('layout-change', () => {

--- a/src/view.ts
+++ b/src/view.ts
@@ -920,12 +920,14 @@ export class PortalsView extends ItemView {
 
     private getCurrentContextNote(): TFile | null {
         // Resolve context note from the active file's parent folder
-        const activeFile = this.app.workspace.getActiveFile();
-        if (activeFile && activeFile.parent) {
-            const note = this.getContextNote(activeFile.parent);
-            if (note) return note;
+        if (this.plugin.settings.contextNoteFollowActive) {
+            const activeFile = this.app.workspace.getActiveFile();
+            if (activeFile && activeFile.parent) {
+                const note = this.getContextNote(activeFile.parent);
+                if (note) return note;
+            }
         }
-        // Fall back to selectedSpace when there is no active file
+        // Fall back to selectedSpace
         const selectedSpace = this.plugin.settings.selectedSpace;
         if (!selectedSpace) return null;
         if (selectedSpace.type === 'folder') {


### PR DESCRIPTION
Add a configuration toggle to allow displaying the "closest" context note, rather than the portal's root context note, in the side panel.